### PR TITLE
Organize tests into suites and add unit coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,8 +16,11 @@
         backupStaticProperties="false"
 >
     <testsuites>
-        <testsuite name="N3XT0R Test Suite">
-            <directory>tests</directory>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
     <coverage pathCoverage="true">

--- a/tests/Integration/FilamentLockboxCommandTest.php
+++ b/tests/Integration/FilamentLockboxCommandTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Integration;
+
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+
+class FilamentLockboxCommandTest extends TestCase
+{
+    public function testCommandRunsSuccessfully(): void
+    {
+        $this->artisan('filament-lockbox')
+            ->expectsOutput('All done')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Unit/FilamentLockboxPluginTest.php
+++ b/tests/Unit/FilamentLockboxPluginTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit;
+
+use N3XT0R\FilamentLockbox\FilamentLockboxPlugin;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+
+class FilamentLockboxPluginTest extends TestCase
+{
+    public function testGetIdReturnsExpectedValue(): void
+    {
+        $plugin = new FilamentLockboxPlugin();
+
+        $this->assertSame('filament-lockbox', $plugin->getId());
+    }
+
+    public function testMakeReturnsInstance(): void
+    {
+        $plugin = FilamentLockboxPlugin::make();
+
+        $this->assertInstanceOf(FilamentLockboxPlugin::class, $plugin);
+    }
+}

--- a/tests/Unit/UserKeyMaterialResolverTest.php
+++ b/tests/Unit/UserKeyMaterialResolverTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit;
+
+use Illuminate\Foundation\Auth\User;
+use N3XT0R\FilamentLockbox\Contracts\UserKeyMaterialProviderInterface;
+use N3XT0R\FilamentLockbox\Support\UserKeyMaterialResolver;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class UserKeyMaterialResolverTest extends TestCase
+{
+    public function testResolveReturnsValueFromSupportingProvider(): void
+    {
+        $provider = new class implements UserKeyMaterialProviderInterface {
+            public function supports(User $user): bool
+            {
+                return true;
+            }
+
+            public function provide(User $user, ?string $input): string
+            {
+                return 'secret';
+            }
+        };
+
+        $resolver = new UserKeyMaterialResolver([$provider]);
+        $user = new User();
+
+        $this->assertSame('secret', $resolver->resolve($user, null));
+    }
+
+    public function testRegisterProviderAddsProvider(): void
+    {
+        $resolver = new UserKeyMaterialResolver();
+
+        $resolver->registerProvider(new class implements UserKeyMaterialProviderInterface {
+            public function supports(User $user): bool
+            {
+                return true;
+            }
+
+            public function provide(User $user, ?string $input): string
+            {
+                return 'abc';
+            }
+        });
+
+        $user = new User();
+
+        $this->assertSame('abc', $resolver->resolve($user, null));
+    }
+
+    public function testResolveThrowsExceptionWhenNoProviderSupportsUser(): void
+    {
+        $resolver = new UserKeyMaterialResolver();
+        $user = new User();
+
+        $this->expectException(RuntimeException::class);
+        $resolver->resolve($user, null);
+    }
+}


### PR DESCRIPTION
## Summary
- Split PHPUnit into Unit and Integration suites
- Add unit tests for plugin and user key resolver
- Cover command execution with integration test

## Testing
- `./vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_68c5458b6e98832992c843134c62bd2c