### PR TITLE
Add polymorphic lockbox storage for encrypted model values

### DIFF
--- a/database/migrations/2025_09_12_213517_create_lockbox_table.php
+++ b/database/migrations/2025_09_12_213517_create_lockbox_table.php
@@ -7,11 +7,10 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
-        Schema::create('lockbox', function (Blueprint $table) {
+        Schema::create('lockbox', function (Blueprint $table): void {
             $table->id();
             $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
             $table->morphs('lockboxable');
@@ -19,5 +18,10 @@ return new class extends Migration
             $table->text('value');
             $table->timestamps();
         });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lockbox');
     }
 };

--- a/src/Concerns/InteractsWithLockbox.php
+++ b/src/Concerns/InteractsWithLockbox.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Foundation\Auth\User;
+use N3XT0R\FilamentLockbox\Models\Lockbox;
+use N3XT0R\FilamentLockbox\Support\LockboxService;
+use RuntimeException;
+
+/** @phpstan-ignore-next-line */
+trait InteractsWithLockbox
+{
+    public function lockbox(): MorphMany
+    {
+        $this->ensureModelContext();
+
+        /** @var Model $this */
+        return $this->morphMany(Lockbox::class, 'lockboxable');
+    }
+
+    public function setLockboxValue(string $name, string $value, User $user): void
+    {
+        $this->ensureModelContext();
+
+        app(LockboxService::class)->set($this, $name, $value, $user);
+    }
+
+    public function getLockboxValue(string $name, User $user): ?string
+    {
+        $this->ensureModelContext();
+
+        return app(LockboxService::class)->get($this, $name, $user);
+    }
+
+    protected function ensureModelContext(): void
+    {
+        if (!$this instanceof Model) {
+            throw new RuntimeException(static::class . ' must be used on an Eloquent Model.');
+        }
+    }
+}

--- a/src/Contracts/HasLockbox.php
+++ b/src/Contracts/HasLockbox.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Contracts;
+
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Foundation\Auth\User;
+
+interface HasLockbox
+{
+    public function lockbox(): MorphMany;
+
+    public function setLockboxValue(string $name, string $value, User $user): void;
+
+    public function getLockboxValue(string $name, User $user): ?string;
+}

--- a/src/FilamentLockboxServiceProvider.php
+++ b/src/FilamentLockboxServiceProvider.php
@@ -192,6 +192,7 @@ class FilamentLockboxServiceProvider extends PackageServiceProvider
     {
         return [
             '2025_09_12_213516_add_lockbox_fields_to_users_table',
+            '2025_09_12_213517_create_lockbox_table',
         ];
     }
 }

--- a/src/Models/Lockbox.php
+++ b/src/Models/Lockbox.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Foundation\Auth\User;
+
+/**
+ * @property int $user_id
+ * @property string $name
+ * @property string $value
+ */
+class Lockbox extends Model
+{
+    protected $table = 'lockbox';
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'value',
+    ];
+
+    public function lockboxable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/src/Support/LockboxService.php
+++ b/src/Support/LockboxService.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Support;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User;
+use N3XT0R\FilamentLockbox\Contracts\HasLockbox;
+
+class LockboxService
+{
+    public function set(Model&HasLockbox $lockboxable, string $name, string $value, User $user): void
+    {
+        $encrypter = app(LockboxManager::class)->forUser($user);
+
+        $lockboxable->lockbox()->updateOrCreate(
+            ['name' => $name, 'user_id' => $user->getKey()],
+            ['value' => $encrypter->encrypt($value)],
+        );
+    }
+
+    public function get(Model&HasLockbox $lockboxable, string $name, User $user): ?string
+    {
+        /** @var \N3XT0R\FilamentLockbox\Models\Lockbox|null $record */
+        $record = $lockboxable->lockbox()
+            ->where('name', $name)
+            ->where('user_id', $user->getKey())
+            ->first();
+
+        if ($record === null) {
+            return null;
+        }
+
+        $encrypter = app(LockboxManager::class)->forUser($user);
+
+        return $encrypter->decrypt($record->value);
+    }
+}


### PR DESCRIPTION
## Summary
- add `lockbox` table to store encrypted model values
- provide `HasLockbox` interface and `InteractsWithLockbox` trait for polymorphic storage
- introduce `Lockbox` model and register migration
- associate lockbox entries with a user for per-user encryption
- extract set/get storage logic into a dedicated `LockboxService`

## Testing
- `composer lint`
- `vendor/bin/phpunit --no-coverage`
- `php -d memory_limit=512M vendor/bin/phpstan analyse`


------
https://chatgpt.com/codex/tasks/task_e_68c570f1a2f08329919433be4d9afe20