### PR TITLE
Add unit tests for support, facade, and form components

### DIFF
--- a/tests/Unit/CryptoPasswordKeyMaterialProviderTest.php
+++ b/tests/Unit/CryptoPasswordKeyMaterialProviderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Support;
+
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Hash;
+use N3XT0R\FilamentLockbox\Concerns\InteractsWithLockboxKeys;
+use N3XT0R\FilamentLockbox\Contracts\HasLockboxKeys;
+use N3XT0R\FilamentLockbox\Support\KeyMaterial\CryptoPasswordKeyMaterialProvider;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+
+class CryptoPasswordKeyMaterialProviderTest extends TestCase
+{
+    private function createUser(string $password): User&HasLockboxKeys
+    {
+        $user = new class () extends User implements HasLockboxKeys {
+            use InteractsWithLockboxKeys;
+            protected $guarded = [];
+        };
+
+        $user->id = 1;
+        $user->setAttribute('crypto_password_hash', Hash::make($password));
+
+        return $user;
+    }
+
+    public function testSupportsReturnsTrueWhenHashExists(): void
+    {
+        $user = $this->createUser('secret');
+        $provider = new CryptoPasswordKeyMaterialProvider();
+
+        $this->assertTrue($provider->supports($user));
+    }
+
+    public function testProvideReturnsDerivedKeyForValidPassword(): void
+    {
+        $password = 'secret';
+        $user = $this->createUser($password);
+        $provider = new CryptoPasswordKeyMaterialProvider();
+
+        $key = $provider->provide($user, $password);
+
+        $this->assertSame(32, strlen($key));
+    }
+}

--- a/tests/Unit/DecryptedTextDisplayTest.php
+++ b/tests/Unit/DecryptedTextDisplayTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Forms;
+
+use N3XT0R\FilamentLockbox\Forms\Components\DecryptedTextDisplay;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+class DecryptedTextDisplayTest extends TestCase
+{
+    public function testSetLockboxInputStoresValue(): void
+    {
+        $component = new DecryptedTextDisplay('field');
+        $component->setLockboxInput('secret');
+
+        $prop = new ReflectionProperty(DecryptedTextDisplay::class, 'lockboxInput');
+        $prop->setAccessible(true);
+
+        $this->assertSame('secret', $prop->getValue($component));
+    }
+}

--- a/tests/Unit/EncryptedTextInputTest.php
+++ b/tests/Unit/EncryptedTextInputTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Forms;
+
+use N3XT0R\FilamentLockbox\Forms\Components\EncryptedTextInput;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+class EncryptedTextInputTest extends TestCase
+{
+    public function testSetLockboxInputStoresValue(): void
+    {
+        $component = new EncryptedTextInput('secret');
+        $component->setLockboxInput('code');
+
+        $prop = new ReflectionProperty(EncryptedTextInput::class, 'lockboxInput');
+        $prop->setAccessible(true);
+
+        $this->assertSame('code', $prop->getValue($component));
+    }
+}

--- a/tests/Unit/FilamentLockboxFacadeTest.php
+++ b/tests/Unit/FilamentLockboxFacadeTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Facades;
+
+use N3XT0R\FilamentLockbox\Facades\FilamentLockbox;
+use N3XT0R\FilamentLockbox\FilamentLockbox as FilamentLockboxRoot;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+
+class FilamentLockboxFacadeTest extends TestCase
+{
+    public function testFacadeResolvesFilamentLockbox(): void
+    {
+        $this->assertInstanceOf(FilamentLockboxRoot::class, FilamentLockbox::getFacadeRoot());
+    }
+}

--- a/tests/Unit/LockboxManagerTest.php
+++ b/tests/Unit/LockboxManagerTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace N3XT0R\FilamentLockbox\Tests\Unit\Support;
 
 use Illuminate\Foundation\Auth\User;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Crypt;
 use N3XT0R\FilamentLockbox\Concerns\InteractsWithLockboxKeys;
 use N3XT0R\FilamentLockbox\Contracts\HasLockboxKeys;
 use N3XT0R\FilamentLockbox\Contracts\UserKeyMaterialProviderInterface;

--- a/tests/Unit/LockboxManagerTest.php
+++ b/tests/Unit/LockboxManagerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Support;
+
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Config;
+use N3XT0R\FilamentLockbox\Concerns\InteractsWithLockboxKeys;
+use N3XT0R\FilamentLockbox\Contracts\HasLockboxKeys;
+use N3XT0R\FilamentLockbox\Contracts\UserKeyMaterialProviderInterface;
+use N3XT0R\FilamentLockbox\Support\LockboxManager;
+use N3XT0R\FilamentLockbox\Support\UserKeyMaterialResolver;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+
+class LockboxManagerTest extends TestCase
+{
+    public function testForUserReturnsWorkingEncrypter(): void
+    {
+        Config::set('app.key', 'base64:' . base64_encode(random_bytes(32)));
+        $partA = 'server-part';
+        $encryptedKey = Crypt::encryptString($partA);
+
+        $user = new class () extends User implements HasLockboxKeys {
+            use InteractsWithLockboxKeys;
+            protected $guarded = [];
+        };
+        $user->id = 1;
+        $user->setAttribute('encrypted_user_key', $encryptedKey);
+
+        $provider = new class () implements UserKeyMaterialProviderInterface {
+            public function supports(User $user): bool
+            {
+                return true;
+            }
+
+            public function provide(User $user, ?string $input): string
+            {
+                return 'user-part';
+            }
+        };
+
+        $resolver = new UserKeyMaterialResolver([$provider]);
+        $this->app->instance(UserKeyMaterialResolver::class, $resolver);
+
+        $manager = new LockboxManager();
+
+        $encrypter = $manager->forUser($user, null, $provider::class);
+
+        $cipher = $encrypter->encryptString('secret');
+        $this->assertSame('secret', $encrypter->decryptString($cipher));
+    }
+}

--- a/tests/Unit/LockboxServiceTest.php
+++ b/tests/Unit/LockboxServiceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Support;
+
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Foundation\Auth\User;
+use N3XT0R\FilamentLockbox\Concerns\InteractsWithLockbox;
+use N3XT0R\FilamentLockbox\Contracts\HasLockbox;
+use N3XT0R\FilamentLockbox\Support\LockboxManager;
+use N3XT0R\FilamentLockbox\Support\LockboxService;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+
+class LockboxServiceTest extends TestCase
+{
+    public function testSetAndGetStoresEncryptedValue(): void
+    {
+        $user = new class () extends User implements HasLockbox {
+            use InteractsWithLockbox;
+            protected $guarded = [];
+            protected $table = 'users';
+        };
+        $user->forceFill([
+            'name' => 'Test',
+            'email' => 'test@example.com',
+            'password' => bcrypt('password'),
+        ])->save();
+
+        $key = random_bytes(32);
+        $encrypter = new Encrypter($key, config('app.cipher'));
+
+        $manager = new class ($encrypter) extends LockboxManager {
+            public function __construct(private Encrypter $encrypter) {}
+            public function forUser(User $user, ?string $input = null, ?string $providerClass = null): Encrypter
+            {
+                return $this->encrypter;
+            }
+        };
+        $this->app->instance(LockboxManager::class, $manager);
+
+        $service = new LockboxService();
+
+        $service->set($user, 'api', 'value123', $user);
+
+        $this->assertDatabaseHas('lockbox', ['name' => 'api', 'user_id' => $user->id]);
+
+        $retrieved = $service->get($user, 'api', $user);
+        $this->assertSame('value123', $retrieved);
+    }
+}

--- a/tests/Unit/LockboxServiceTest.php
+++ b/tests/Unit/LockboxServiceTest.php
@@ -31,7 +31,10 @@ class LockboxServiceTest extends TestCase
         $encrypter = new Encrypter($key, config('app.cipher'));
 
         $manager = new class ($encrypter) extends LockboxManager {
-            public function __construct(private Encrypter $encrypter) {}
+            public function __construct(private Encrypter $encrypter)
+            {
+            }
+
             public function forUser(User $user, ?string $input = null, ?string $providerClass = null): Encrypter
             {
                 return $this->encrypter;

--- a/tests/Unit/PackageTest.php
+++ b/tests/Unit/PackageTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Support;
+
+use N3XT0R\FilamentLockbox\Support\Composer\Package;
+use PHPUnit\Framework\TestCase;
+
+class PackageTest extends TestCase
+{
+    public function testIsInstalledReturnsExpectedValues(): void
+    {
+        $this->assertTrue(Package::isInstalled('phpunit/phpunit'));
+        $this->assertFalse(Package::isInstalled('nonexistent/package'));
+    }
+
+    public function testGetVersionReturnsStringOrNull(): void
+    {
+        $this->assertIsString(Package::getVersion('phpunit/phpunit'));
+        $this->assertNull(Package::getVersion('nonexistent/package'));
+    }
+}

--- a/tests/Unit/UnlockLockboxActionTest.php
+++ b/tests/Unit/UnlockLockboxActionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Forms;
+
+use Illuminate\Http\Request;
+use N3XT0R\FilamentLockbox\Forms\Actions\UnlockLockboxAction;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+
+class UnlockLockboxActionTest extends TestCase
+{
+    public function testGetDefaultNameReturnsUnlockLockbox(): void
+    {
+        $this->assertSame('unlockLockbox', UnlockLockboxAction::getDefaultName());
+    }
+
+    public function testActionMergesInputIntoRequest(): void
+    {
+        $request = Request::create('/');
+        $this->app->instance('request', $request);
+
+        $action = UnlockLockboxAction::make();
+        $closure = $action->getActionFunction();
+        $this->assertNotNull($closure);
+
+        $closure(['lockbox_input' => 'secret']);
+
+        $this->assertSame('secret', request('lockbox_input'));
+    }
+}


### PR DESCRIPTION
## Summary
- cover composer package helpers
- test key material and lockbox services
- add facade and form component tests

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c6cfe2856483298bf8dbbd2a52d527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests covering lockbox encryption/decryption and key handling to improve reliability.
  * Verified password‑derived key support and that assembled encrypters perform correct round‑trip encryption.
  * Ensured lockbox service stores and retrieves encrypted values.
  * Confirmed form components capture and propagate lockbox input.
  * Validated action defaults and request‑merging behavior.
  * Checked facade resolution consistency and package installation/version checks for environment validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->