### PR TITLE
test: add integration tests for lockbox

### DIFF
--- a/tests/Integration/LockboxManagerTest.php
+++ b/tests/Integration/LockboxManagerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Integration;
+
+use Illuminate\Foundation\Auth\User as BaseUser;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Hash;
+use N3XT0R\FilamentLockbox\Contracts\HasLockboxKeys;
+use N3XT0R\FilamentLockbox\Support\KeyMaterial\CryptoPasswordKeyMaterialProvider;
+use N3XT0R\FilamentLockbox\Support\LockboxManager;
+use N3XT0R\FilamentLockbox\Support\UserKeyMaterialResolver;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+
+class LockboxUser extends BaseUser implements HasLockboxKeys
+{
+    public ?string $encryptedUserKey = null;
+    public ?string $cryptoPasswordHash = null;
+    public ?string $providerClass = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->encryptedUserKey = Crypt::encryptString('server-part');
+        $this->cryptoPasswordHash = Hash::make('top-secret');
+        $this->providerClass = CryptoPasswordKeyMaterialProvider::class;
+    }
+
+    public function getEncryptedUserKey(): ?string
+    {
+        return $this->encryptedUserKey;
+    }
+
+    public function setEncryptedUserKey(string $value): void
+    {
+        $this->encryptedUserKey = $value;
+    }
+
+    public function getCryptoPasswordHash(): ?string
+    {
+        return $this->cryptoPasswordHash;
+    }
+
+    public function setCryptoPasswordHash(string $hash): void
+    {
+        $this->cryptoPasswordHash = $hash;
+    }
+
+    public function getLockboxProvider(): ?string
+    {
+        return $this->providerClass;
+    }
+
+    public function setLockboxProvider(string $provider): void
+    {
+        $this->providerClass = $provider;
+    }
+
+    public function initializeUserKeyIfMissing(): void
+    {
+        // no-op for tests
+    }
+
+    public function setCryptoPassword(string $plainPassword): void
+    {
+        $this->cryptoPasswordHash = Hash::make($plainPassword);
+    }
+}
+
+class LockboxManagerTest extends TestCase
+{
+    public function testManagerEncryptsAndDecryptsUsingCryptoPassword(): void
+    {
+        config(['app.key' => 'base64:' . base64_encode(random_bytes(32))]);
+
+        $user = new LockboxUser();
+        $user->id = 1;
+
+        /** @var UserKeyMaterialResolver $resolver */
+        $resolver = app(UserKeyMaterialResolver::class);
+        $resolver->registerProvider(new CryptoPasswordKeyMaterialProvider());
+
+        $manager = app(LockboxManager::class);
+        $encrypter = $manager->forUser($user, 'top-secret');
+
+        $cipher = $encrypter->encryptString('plain-data');
+        $this->assertSame('plain-data', $encrypter->decryptString($cipher));
+    }
+}

--- a/tests/Integration/UserKeyMaterialResolverTest.php
+++ b/tests/Integration/UserKeyMaterialResolverTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Integration;
+
+use Filament\Auth\MultiFactor\App\AppAuthentication;
+use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
+use Illuminate\Foundation\Auth\User as BaseUser;
+use N3XT0R\FilamentLockbox\Support\KeyMaterial\TotpKeyMaterialProvider;
+use N3XT0R\FilamentLockbox\Support\UserKeyMaterialResolver;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+
+class TotpUser extends BaseUser implements HasAppAuthentication
+{
+    public ?string $appAuthenticationSecret = 'totp-secret';
+
+    public function getAppAuthenticationSecret(): ?string
+    {
+        return $this->appAuthenticationSecret;
+    }
+
+    public function saveAppAuthenticationSecret(?string $secret): void
+    {
+        $this->appAuthenticationSecret = $secret;
+    }
+
+    public function getAppAuthenticationHolderName(): string
+    {
+        return 'Test User';
+    }
+}
+
+class UserKeyMaterialResolverTest extends TestCase
+{
+    public function testResolveUsesTotpProviderWithVerifiedCode(): void
+    {
+        config(['app.key' => 'base64:' . base64_encode(random_bytes(32))]);
+
+        $user = new TotpUser();
+        $user->id = 1;
+
+        $this->mock(AppAuthentication::class)
+            ->shouldReceive('verifyCode')
+            ->once()
+            ->with('123456', $user->getAppAuthenticationSecret())
+            ->andReturn(true);
+
+        /** @var UserKeyMaterialResolver $resolver */
+        $resolver = app(UserKeyMaterialResolver::class);
+        $resolver->registerProvider(new TotpKeyMaterialProvider());
+
+        $material = $resolver->resolve($user, '123456');
+        $this->assertSame(
+            hash('sha256', '123456' . $user->getKey(), true),
+            $material,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add integration test for LockboxManager using CryptoPasswordKeyMaterialProvider
- cover UserKeyMaterialResolver with TOTP provider and mocked AppAuthentication

## Testing
- `vendor/bin/phpunit tests/Integration/LockboxManagerTest.php tests/Integration/UserKeyMaterialResolverTest.php`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6d9d8e6f483299dd0ab441445d0a4