### PR TITLE
Add unit tests for lockbox key providers and widgets

### DIFF
--- a/tests/Unit/LockboxStatusWidgetTest.php
+++ b/tests/Unit/LockboxStatusWidgetTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Widgets;
+
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Auth;
+use N3XT0R\FilamentLockbox\Concerns\InteractsWithLockboxKeys;
+use N3XT0R\FilamentLockbox\Contracts\HasLockboxKeys;
+use N3XT0R\FilamentLockbox\Support\KeyMaterial\CryptoPasswordKeyMaterialProvider;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+use N3XT0R\FilamentLockbox\Widgets\LockboxStatusWidget;
+
+class LockboxStatusWidgetTest extends TestCase
+{
+    public function testMountWithoutSupportDisablesWidget(): void
+    {
+        $user = new User();
+        Auth::login($user);
+
+        $widget = new LockboxStatusWidget();
+        $widget->mount();
+
+        $this->assertFalse($widget->supportsLockbox);
+    }
+
+    public function testMountWithSupportingUserSetsProvider(): void
+    {
+        $user = new class () extends User implements HasLockboxKeys {
+            use InteractsWithLockboxKeys;
+            protected $guarded = [];
+        };
+        $user->id = 1;
+        $user->setAttribute('lockbox_provider', CryptoPasswordKeyMaterialProvider::class);
+        Auth::login($user);
+
+        $widget = new LockboxStatusWidget();
+        $widget->mount();
+
+        $this->assertTrue($widget->supportsLockbox);
+        $this->assertSame(CryptoPasswordKeyMaterialProvider::class, $widget->provider);
+    }
+}

--- a/tests/Unit/LockboxTest.php
+++ b/tests/Unit/LockboxTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use N3XT0R\FilamentLockbox\Models\Lockbox;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+
+class LockboxTest extends TestCase
+{
+    public function testRelationshipsReturnExpectedTypes(): void
+    {
+        $lockbox = new Lockbox();
+
+        $this->assertInstanceOf(BelongsTo::class, $lockbox->user());
+        $this->assertInstanceOf(MorphTo::class, $lockbox->lockboxable());
+    }
+}

--- a/tests/Unit/PasskeyKeyMaterialProviderTest.php
+++ b/tests/Unit/PasskeyKeyMaterialProviderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Support;
+
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Auth\User;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use N3XT0R\FilamentLockbox\Support\KeyMaterial\PasskeyKeyMaterialProvider;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
+use Spatie\LaravelPasskeys\Models\Passkey;
+
+class PasskeyKeyMaterialProviderTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testSupportsReturnsTrueForHasPasskeysUser(): void
+    {
+        $user = Mockery::mock(User::class, HasPasskeys::class);
+        $provider = new PasskeyKeyMaterialProvider();
+        $this->assertTrue($provider->supports($user));
+    }
+
+    public function testProvideReturnsDerivedKeyUsingSessionPasskey(): void
+    {
+        config(['app.key' => 'test-app-key']);
+
+        $user = Mockery::mock(User::class, HasPasskeys::class);
+        $user->shouldReceive('getKey')->andReturn(1);
+
+        $passkey = new Passkey();
+        $passkey->id = 10;
+        $passkey->setAttribute('credential_id', 'cred');
+
+        $relation = Mockery::mock(HasMany::class);
+        $relation->shouldReceive('exists')->andReturn(true);
+        $relation->shouldReceive('find')->with(10)->andReturn($passkey);
+        $user->shouldReceive('passkeys')->andReturn($relation);
+
+        session()->put('lockbox_passkey_verified', [
+            'timestamp' => now()->getTimestamp(),
+            'passkey_id' => 10,
+        ]);
+
+        $provider = new PasskeyKeyMaterialProvider();
+        $key = $provider->provide($user, null);
+
+        $expected = hash('sha256', hash_hmac('sha256', 'cred', 'test-app-key') . 1, true);
+        $this->assertSame($expected, $key);
+    }
+}

--- a/tests/Unit/ReencryptLockboxDataTest.php
+++ b/tests/Unit/ReencryptLockboxDataTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Jobs;
+
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Foundation\Auth\User;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use N3XT0R\FilamentLockbox\Jobs\ReencryptLockboxData;
+use N3XT0R\FilamentLockbox\Support\LockboxManager;
+use PHPUnit\Framework\TestCase;
+
+class ReencryptLockboxDataTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testHandleInvokesManagerForOldAndNewProviders(): void
+    {
+        $user = new User();
+        $job = new ReencryptLockboxData($user, 'old', 'new');
+
+        $manager = Mockery::mock(LockboxManager::class);
+        $encrypter = new Encrypter(str_repeat('a', 32), 'AES-256-CBC');
+        $manager->shouldReceive('forUser')->once()->with($user, null, 'old')->andReturn($encrypter);
+        $manager->shouldReceive('forUser')->once()->with($user, null, 'new')->andReturn($encrypter);
+
+        $job->handle($manager);
+    }
+}

--- a/tests/Unit/SetLockboxPasskeyFlagTest.php
+++ b/tests/Unit/SetLockboxPasskeyFlagTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Listeners;
+
+use Illuminate\Support\Facades\Session;
+use N3XT0R\FilamentLockbox\Listeners\SetLockboxPasskeyFlag;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+use Spatie\LaravelPasskeys\Events\PasskeyUsedToAuthenticateEvent;
+use Spatie\LaravelPasskeys\Http\Requests\AuthenticateUsingPasskeysRequest;
+use Spatie\LaravelPasskeys\Models\Passkey;
+
+class SetLockboxPasskeyFlagTest extends TestCase
+{
+    public function testHandleStoresSessionFlag(): void
+    {
+        $passkey = new Passkey();
+        $passkey->id = 1;
+
+        $request = AuthenticateUsingPasskeysRequest::create('/', 'POST');
+        $event = new PasskeyUsedToAuthenticateEvent($passkey, $request);
+
+        $listener = new SetLockboxPasskeyFlag();
+        $listener->handle($event);
+
+        $flag = config('filament-lockbox.passkeys.session_flag', 'lockbox_passkey_verified');
+        $data = Session::get($flag);
+
+        $this->assertSame(1, $data['passkey_id']);
+        $this->assertArrayHasKey('timestamp', $data);
+    }
+}

--- a/tests/Unit/TotpKeyMaterialProviderTest.php
+++ b/tests/Unit/TotpKeyMaterialProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\FilamentLockbox\Tests\Unit\Support;
+
+use Filament\Auth\MultiFactor\App\AppAuthentication;
+use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
+use Illuminate\Foundation\Auth\User;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use N3XT0R\FilamentLockbox\Support\KeyMaterial\TotpKeyMaterialProvider;
+use N3XT0R\FilamentLockbox\Tests\TestCase;
+
+class TotpKeyMaterialProviderTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private function createUser(string $secret): User&HasAppAuthentication
+    {
+        $user = new class () extends User implements HasAppAuthentication {
+            public ?string $secret = null;
+            protected $guarded = [];
+
+            public function getAppAuthenticationSecret(): ?string
+            {
+                return $this->secret;
+            }
+
+            public function saveAppAuthenticationSecret(?string $secret): void
+            {
+                $this->secret = $secret;
+            }
+
+            public function getAppAuthenticationHolderName(): string
+            {
+                return 'Holder';
+            }
+        };
+        $user->id = 1;
+        $user->secret = $secret;
+
+        return $user;
+    }
+
+    public function testSupportsReturnsTrueWhenSecretPresent(): void
+    {
+        $user = $this->createUser('secret');
+        $provider = new TotpKeyMaterialProvider();
+        $this->assertTrue($provider->supports($user));
+    }
+
+    public function testProvideReturnsDerivedKeyForValidCode(): void
+    {
+        $user = $this->createUser('secret');
+        $provider = new TotpKeyMaterialProvider();
+
+        $mock = Mockery::mock(AppAuthentication::class);
+        $mock->shouldReceive('verifyCode')->with('123456', 'secret')->andReturn(true);
+        $this->app->instance(AppAuthentication::class, $mock);
+
+        $key = $provider->provide($user, '123456');
+        $expected = hash('sha256', '123456' . $user->getKey(), true);
+        $this->assertSame($expected, $key);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for passkey session flag listener and re-encryption job
- cover lockbox model relationships and status widget behavior
- test key material providers for crypto password, TOTP, and passkey scenarios

## Testing
- `composer lint`
- `vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c6edb5569c832983529fbb01081a96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Expanded unit test coverage for lockbox status behavior with supported and unsupported users.
  - Added tests for key material providers (password, passkey, TOTP), including validation, error handling, and derived key generation.
  - Verified lockbox model relationships through dedicated tests.
  - Added tests for the re-encryption process across providers to ensure correct execution.
  - Ensured session flags are correctly set after passkey authentication.
  - Minor test suite cleanup to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->