### PR TITLE
Add doc comments to key material providers

### DIFF
--- a/src/Support/KeyMaterial/CryptoPasswordKeyMaterialProvider.php
+++ b/src/Support/KeyMaterial/CryptoPasswordKeyMaterialProvider.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Key material provider that derives material from a user's crypto password.
+ */
 
 declare(strict_types=1);
 
@@ -10,13 +13,24 @@ use N3XT0R\FilamentLockbox\Contracts\HasLockboxKeys;
 use N3XT0R\FilamentLockbox\Contracts\UserKeyMaterialProviderInterface;
 use RuntimeException;
 
+/**
+ * Generates key material from a user-provided crypto password.
+ */
 class CryptoPasswordKeyMaterialProvider implements UserKeyMaterialProviderInterface
 {
+    /**
+     * Determine if the user has a crypto password configured.
+     */
     public function supports(User $user): bool
     {
         return $user instanceof HasLockboxKeys && !empty($user->getCryptoPasswordHash());
     }
 
+    /**
+     * Return key material derived from the validated crypto password.
+     *
+     * @throws RuntimeException when the input is missing or invalid
+     */
     public function provide(User $user, ?string $input): string
     {
         if (!$user instanceof HasLockboxKeys) {

--- a/src/Support/KeyMaterial/PasskeyKeyMaterialProvider.php
+++ b/src/Support/KeyMaterial/PasskeyKeyMaterialProvider.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Key material provider that derives encryption material from a user's passkey.
+ */
 
 declare(strict_types=1);
 
@@ -10,13 +13,24 @@ use RuntimeException;
 use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
 use Spatie\LaravelPasskeys\Models\Passkey;
 
+/**
+ * Provides key material based on verified passkey credentials.
+ */
 class PasskeyKeyMaterialProvider implements UserKeyMaterialProviderInterface
 {
+    /**
+     * Determine if the user supports passkey-based key material.
+     */
     public function supports(User $user): bool
     {
         return $user instanceof HasPasskeys;
     }
 
+    /**
+     * Return deterministic key material derived from the authenticated passkey.
+     *
+     * @throws RuntimeException when passkey data is missing or invalid
+     */
     public function provide(User $user, ?string $input): string
     {
         if (!$this->supports($user)) {

--- a/src/Support/KeyMaterial/TotpKeyMaterialProvider.php
+++ b/src/Support/KeyMaterial/TotpKeyMaterialProvider.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Key material provider that validates a TOTP code from the user.
+ */
 
 declare(strict_types=1);
 
@@ -10,13 +13,24 @@ use Illuminate\Foundation\Auth\User;
 use N3XT0R\FilamentLockbox\Contracts\UserKeyMaterialProviderInterface;
 use RuntimeException;
 
+/**
+ * Generates key material using a time-based one-time password (TOTP).
+ */
 class TotpKeyMaterialProvider implements UserKeyMaterialProviderInterface
 {
+    /**
+     * Determine if the user has TOTP authentication enabled.
+     */
     public function supports(User $user): bool
     {
         return $user instanceof HasAppAuthentication && !empty($user->getAppAuthenticationSecret());
     }
 
+    /**
+     * Return key material after verifying the provided TOTP code.
+     *
+     * @throws RuntimeException when verification fails
+     */
     public function provide(User $user, ?string $input): string
     {
         if (!$user instanceof HasAppAuthentication) {


### PR DESCRIPTION
## Summary
- document PasskeyKeyMaterialProvider
- document TotpKeyMaterialProvider
- document CryptoPasswordKeyMaterialProvider

## Testing
- `./vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c6ee1f52c88329b838c6c11e18e006