### PR TITLE
docs: add docblocks for php classes

### DIFF
--- a/src/Commands/FilamentLockboxCommand.php
+++ b/src/Commands/FilamentLockboxCommand.php
@@ -6,12 +6,26 @@ namespace N3XT0R\FilamentLockbox\Commands;
 
 use Illuminate\Console\Command;
 
+/**
+ * Console command for Filament Lockbox.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ */
 class FilamentLockboxCommand extends Command
 {
     public $signature = 'filament-lockbox';
 
     public $description = 'My command';
 
+    /**
+     * Execute the console command.
+     *
+     * @return int Command exit code
+     */
     public function handle(): int
     {
         $this->comment('All done');

--- a/src/Concerns/InteractsWithLockbox.php
+++ b/src/Concerns/InteractsWithLockbox.php
@@ -12,8 +12,22 @@ use N3XT0R\FilamentLockbox\Support\LockboxService;
 use RuntimeException;
 
 /** @phpstan-ignore-next-line */
+/**
+ * Adds lockbox relation and helpers to models.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ */
 trait InteractsWithLockbox
 {
+    /**
+     * Define the lockbox relationship.
+     *
+     * @return MorphMany
+     */
     public function lockbox(): MorphMany
     {
         $this->ensureModelContext();
@@ -22,6 +36,15 @@ trait InteractsWithLockbox
         return $this->morphMany(Lockbox::class, 'lockboxable');
     }
 
+    /**
+     * Store an encrypted value for the model.
+     *
+     * @param string $name  Lockbox item name
+     * @param string $value Plain text value to encrypt
+     * @param User   $user  User owning the data
+     *
+     * @return void
+     */
     public function setLockboxValue(string $name, string $value, User $user): void
     {
         $this->ensureModelContext();
@@ -29,6 +52,14 @@ trait InteractsWithLockbox
         app(LockboxService::class)->set($this, $name, $value, $user);
     }
 
+    /**
+     * Retrieve and decrypt an item from the model's lockbox.
+     *
+     * @param string $name Lockbox item name
+     * @param User   $user User owning the data
+     *
+     * @return string|null Decrypted value or null when missing
+     */
     public function getLockboxValue(string $name, User $user): ?string
     {
         $this->ensureModelContext();
@@ -36,6 +67,13 @@ trait InteractsWithLockbox
         return app(LockboxService::class)->get($this, $name, $user);
     }
 
+    /**
+     * Ensure this trait is used within an Eloquent model.
+     *
+     * @throws RuntimeException If not used on a model
+     *
+     * @return void
+     */
     protected function ensureModelContext(): void
     {
         if (!$this instanceof Model) {

--- a/src/Concerns/InteractsWithLockboxKeys.php
+++ b/src/Concerns/InteractsWithLockboxKeys.php
@@ -10,8 +10,22 @@ use Illuminate\Support\Facades\Hash;
 use Random\RandomException;
 use RuntimeException;
 
+/**
+ * Provides helper methods for models using lockbox keys.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ */
 trait InteractsWithLockboxKeys
 {
+    /**
+     * Get the encrypted user key.
+     *
+     * @return string|null Encrypted key or null when missing
+     */
     public function getEncryptedUserKey(): ?string
     {
         $this->ensureModelContext();
@@ -20,6 +34,13 @@ trait InteractsWithLockboxKeys
         return $this->getAttribute('encrypted_user_key');
     }
 
+    /**
+     * Store the encrypted user key.
+     *
+     * @param string $value Encrypted key value
+     *
+     * @return void
+     */
     public function setEncryptedUserKey(string $value): void
     {
         $this->ensureModelContext();
@@ -27,6 +48,11 @@ trait InteractsWithLockboxKeys
         $this->setAttribute('encrypted_user_key', $value);
     }
 
+    /**
+     * Get the hash of the user's crypto password.
+     *
+     * @return string|null Hash value or null when unset
+     */
     public function getCryptoPasswordHash(): ?string
     {
         $this->ensureModelContext();
@@ -35,6 +61,13 @@ trait InteractsWithLockboxKeys
         return $this->getAttribute('crypto_password_hash');
     }
 
+    /**
+     * Set the hash of the user's crypto password.
+     *
+     * @param string $hash Hashed password value
+     *
+     * @return void
+     */
     public function setCryptoPasswordHash(string $hash): void
     {
         $this->ensureModelContext();
@@ -42,6 +75,11 @@ trait InteractsWithLockboxKeys
         $this->setAttribute('crypto_password_hash', $hash);
     }
 
+    /**
+     * Get the configured lockbox provider class.
+     *
+     * @return string|null Provider class name
+     */
     public function getLockboxProvider(): ?string
     {
         $this->ensureModelContext();
@@ -50,6 +88,13 @@ trait InteractsWithLockboxKeys
         return $this->getAttribute('lockbox_provider');
     }
 
+    /**
+     * Set the lockbox provider class.
+     *
+     * @param string $provider Provider class name
+     *
+     * @return void
+     */
     public function setLockboxProvider(string $provider): void
     {
         $this->ensureModelContext();
@@ -59,8 +104,11 @@ trait InteractsWithLockboxKeys
     }
 
     /**
-     * Generate a new encrypted user key if none exists.
-     * @throws RandomException
+     * Generate and store an encrypted user key if one does not exist.
+     *
+     * @throws RandomException If random bytes cannot be generated
+     *
+     * @return void
      */
     public function initializeUserKeyIfMissing(): void
     {
@@ -76,7 +124,11 @@ trait InteractsWithLockboxKeys
     }
 
     /**
-     * Helper to set a new crypto password and hash it securely.
+     * Hash and store a new crypto password.
+     *
+     * @param string $plainPassword Plain password input
+     *
+     * @return void
      */
     public function setCryptoPassword(string $plainPassword): void
     {
@@ -88,7 +140,9 @@ trait InteractsWithLockboxKeys
     }
 
     /**
-     * Check if a user already has a generated encryption key.
+     * Determine if the model already has an encrypted user key.
+     *
+     * @return bool True if a key exists, false otherwise
      */
     public function hasLockboxKey(): bool
     {
@@ -99,8 +153,11 @@ trait InteractsWithLockboxKeys
     }
 
     /**
-     * Ensure this trait is used within an Eloquent Model context.
-     * @throws RuntimeException
+     * Ensure this trait is used within an Eloquent model context.
+     *
+     * @throws RuntimeException If not used on a model
+     *
+     * @return void
      */
     protected function ensureModelContext(): void
     {

--- a/src/Facades/FilamentLockbox.php
+++ b/src/Facades/FilamentLockbox.php
@@ -7,10 +7,23 @@ namespace N3XT0R\FilamentLockbox\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
+ * Facade for the Filament Lockbox service.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ *
  * @see \N3XT0R\FilamentLockbox\FilamentLockbox
  */
 class FilamentLockbox extends Facade
 {
+    /**
+     * Get the underlying service class.
+     *
+     * @return string
+     */
     protected static function getFacadeAccessor(): string
     {
         return \N3XT0R\FilamentLockbox\FilamentLockbox::class;

--- a/src/FilamentLockbox.php
+++ b/src/FilamentLockbox.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace N3XT0R\FilamentLockbox;
 
+/**
+ * Core Filament Lockbox package class.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ */
 class FilamentLockbox
 {
 }

--- a/src/FilamentLockboxPlugin.php
+++ b/src/FilamentLockboxPlugin.php
@@ -8,13 +8,34 @@ use Filament\Contracts\Plugin;
 use Filament\Panel;
 use N3XT0R\FilamentLockbox\Widgets\LockboxStatusWidget;
 
+/**
+ * Filament plugin registering lockbox widgets.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ */
 class FilamentLockboxPlugin implements Plugin
 {
+    /**
+     * Get the plugin identifier.
+     *
+     * @return string Plugin ID
+     */
     public function getId(): string
     {
         return 'filament-lockbox';
     }
 
+    /**
+     * Register plugin resources on the given panel.
+     *
+     * @param Panel $panel Filament panel instance
+     *
+     * @return void
+     */
     public function register(Panel $panel): void
     {
         if (config('filament-lockbox.show_widget', true)) {
@@ -24,16 +45,33 @@ class FilamentLockboxPlugin implements Plugin
         }
     }
 
+    /**
+     * Boot the plugin.
+     *
+     * @param Panel $panel Filament panel instance
+     *
+     * @return void
+     */
     public function boot(Panel $panel): void
     {
         //
     }
 
+    /**
+     * Create a new plugin instance.
+     *
+     * @return static
+     */
     public static function make(): static
     {
         return app(static::class);
     }
 
+    /**
+     * Retrieve the plugin from the Filament registry.
+     *
+     * @return static
+     */
     public static function get(): static
     {
         /** @var static $plugin */

--- a/src/FilamentLockboxServiceProvider.php
+++ b/src/FilamentLockboxServiceProvider.php
@@ -26,12 +26,28 @@ use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\LaravelPasskeys\Events\PasskeyUsedToAuthenticateEvent;
 
+/**
+ * Service provider for the Filament Lockbox package.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ */
 class FilamentLockboxServiceProvider extends PackageServiceProvider
 {
     public static string $name = 'filament-lockbox';
 
     public static string $viewNamespace = 'filament-lockbox';
 
+    /**
+     * Configure package assets, commands, and resources.
+     *
+     * @param Package $package Package instance to configure
+     *
+     * @return void
+     */
     public function configurePackage(Package $package): void
     {
         /*
@@ -68,10 +84,20 @@ class FilamentLockboxServiceProvider extends PackageServiceProvider
         }
     }
 
+    /**
+     * Execute actions after the package is registered.
+     *
+     * @return void
+     */
     public function packageRegistered(): void
     {
     }
 
+    /**
+     * Boot the package services.
+     *
+     * @return void
+     */
     public function packageBooted(): void
     {
         // Asset Registration
@@ -103,6 +129,11 @@ class FilamentLockboxServiceProvider extends PackageServiceProvider
         $this->registerSingletons();
     }
 
+    /**
+     * Register form components and macros.
+     *
+     * @return void
+     */
     protected function registerComponents(): void
     {
         // Register a macro for convenient usage in Filament forms
@@ -111,6 +142,11 @@ class FilamentLockboxServiceProvider extends PackageServiceProvider
         });
     }
 
+    /**
+     * Register container singletons and event listeners.
+     *
+     * @return void
+     */
     protected function registerSingletons(): void
     {
         $this->app->singleton(UserKeyMaterialResolver::class, function () {
@@ -134,13 +170,20 @@ class FilamentLockboxServiceProvider extends PackageServiceProvider
 
     }
 
+    /**
+     * Get the package name used for asset registration.
+     *
+     * @return string|null Asset package name
+     */
     protected function getAssetPackageName(): ?string
     {
         return 'n3xt0r/filament-lockbox';
     }
 
     /**
-     * @return array<Asset>
+     * Get assets to register with Filament.
+     *
+     * @return array<Asset> Asset definitions
      */
     protected function getAssets(): array
     {
@@ -152,7 +195,9 @@ class FilamentLockboxServiceProvider extends PackageServiceProvider
     }
 
     /**
-     * @return array<class-string>
+     * Get the package's console commands.
+     *
+     * @return array<class-string> Command class names
      */
     protected function getCommands(): array
     {
@@ -162,7 +207,9 @@ class FilamentLockboxServiceProvider extends PackageServiceProvider
     }
 
     /**
-     * @return array<string>
+     * Get icon definitions to register.
+     *
+     * @return array<string> Icon mappings
      */
     protected function getIcons(): array
     {
@@ -170,7 +217,9 @@ class FilamentLockboxServiceProvider extends PackageServiceProvider
     }
 
     /**
-     * @return array<string>
+     * Get additional route files to include.
+     *
+     * @return array<string> Route file paths
      */
     protected function getRoutes(): array
     {
@@ -178,7 +227,9 @@ class FilamentLockboxServiceProvider extends PackageServiceProvider
     }
 
     /**
-     * @return array<string, mixed>
+     * Get script data to expose to the front end.
+     *
+     * @return array<string, mixed> Data key-value pairs
      */
     protected function getScriptData(): array
     {
@@ -186,7 +237,9 @@ class FilamentLockboxServiceProvider extends PackageServiceProvider
     }
 
     /**
-     * @return array<string>
+     * Get migration file names for installation.
+     *
+     * @return array<string> Migration file names
      */
     protected function getMigrations(): array
     {

--- a/src/Forms/Actions/UnlockLockboxAction.php
+++ b/src/Forms/Actions/UnlockLockboxAction.php
@@ -8,14 +8,20 @@ use Filament\Actions\Action;
 use Filament\Forms\Components\TextInput;
 
 /**
- * Opens a modal to collect the user's Lockbox secret (crypto password or TOTP).
- * The provided value is merged into the current request as "lockbox_input",
- * so any EncryptedTextInput can read it during dehydration.
+ * Action to prompt the user for lockbox secret input.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
  */
 class UnlockLockboxAction extends Action
 {
     /**
-     * Provide a sane default name so developers can simply call `UnlockLockboxAction::make()`.
+     * Provide a sane default name so developers can simply call `make()`.
+     *
+     * @return string|null Default name
      */
     public static function getDefaultName(): ?string
     {
@@ -24,6 +30,8 @@ class UnlockLockboxAction extends Action
 
     /**
      * Configure the action: modal, form schema, and behavior.
+     *
+     * @return void
      */
     protected function setUp(): void
     {

--- a/src/Forms/Components/DecryptedTextDisplay.php
+++ b/src/Forms/Components/DecryptedTextDisplay.php
@@ -13,6 +13,12 @@ use N3XT0R\FilamentLockbox\Support\LockboxManager;
 
 /**
  * Displays decrypted value of a field stored with EncryptedTextInput.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
  */
 class DecryptedTextDisplay extends Field
 {
@@ -23,6 +29,13 @@ class DecryptedTextDisplay extends Field
      */
     protected ?string $lockboxInput = null;
 
+    /**
+     * Set the lockbox input used for decryption.
+     *
+     * @param string|null $input Secret provided by the user
+     *
+     * @return static
+     */
     public function setLockboxInput(?string $input): static
     {
         $this->lockboxInput = $input;
@@ -30,6 +43,11 @@ class DecryptedTextDisplay extends Field
         return $this;
     }
 
+    /**
+     * Configure component behavior for decrypting values.
+     *
+     * @return void
+     */
     protected function setUp(): void
     {
         parent::setUp();

--- a/src/Forms/Components/EncryptedTextInput.php
+++ b/src/Forms/Components/EncryptedTextInput.php
@@ -14,6 +14,12 @@ use RuntimeException;
 /**
  * Text input that stores its value encrypted using a per-user key.
  * It masks hydrated values and encrypts on dehydration.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
  */
 class EncryptedTextInput extends TextInput
 {
@@ -22,6 +28,13 @@ class EncryptedTextInput extends TextInput
      */
     protected ?string $lockboxInput = null;
 
+    /**
+     * Set the lockbox secret used for encryption.
+     *
+     * @param string $input Secret provided by the user
+     *
+     * @return static
+     */
     public function setLockboxInput(string $input): static
     {
         $this->lockboxInput = $input;
@@ -29,6 +42,11 @@ class EncryptedTextInput extends TextInput
         return $this;
     }
 
+    /**
+     * Configure component behavior for handling encrypted state.
+     *
+     * @return void
+     */
     protected function setUp(): void
     {
         parent::setUp();

--- a/src/Jobs/ReencryptLockboxData.php
+++ b/src/Jobs/ReencryptLockboxData.php
@@ -11,12 +11,30 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use N3XT0R\FilamentLockbox\Support\LockboxManager;
 
+/**
+ * Job to re-encrypt lockbox data when the provider changes.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ */
 class ReencryptLockboxData implements ShouldQueue
 {
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
 
+    /**
+     * Create a new job instance.
+     *
+     * @param User   $user        User whose data is re-encrypted
+     * @param string $oldProvider Original provider class
+     * @param string $newProvider New provider class
+     *
+     * @return void
+     */
     public function __construct(
         public User $user,
         public string $oldProvider,
@@ -24,6 +42,13 @@ class ReencryptLockboxData implements ShouldQueue
     ) {
     }
 
+    /**
+     * Re-encrypt lockbox data using the new provider.
+     *
+     * @param LockboxManager $manager Lockbox manager instance
+     *
+     * @return void
+     */
     public function handle(LockboxManager $manager): void
     {
         // Acquire encrypter instances for old and new providers

--- a/src/Listeners/SetLockboxPasskeyFlag.php
+++ b/src/Listeners/SetLockboxPasskeyFlag.php
@@ -9,12 +9,23 @@ use Illuminate\Support\Facades\Session;
 use Spatie\LaravelPasskeys\Events\PasskeyUsedToAuthenticateEvent;
 
 /**
- * Marks the current session as passkey-verified after a successful Passkey login.
- * This does not log in the user – Spatie handles that – it only adds a session flag
- * that Lockbox can later read to derive key material (or to allow unlocking).
+ * Sets a session flag after passkey authentication.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
  */
 class SetLockboxPasskeyFlag
 {
+    /**
+     * Store a flag indicating the session was authenticated via passkey.
+     *
+     * @param PasskeyUsedToAuthenticateEvent $event Authentication event
+     *
+     * @return void
+     */
     public function handle(PasskeyUsedToAuthenticateEvent $event): void
     {
         $flag = config('filament-lockbox.passkeys.session_flag', 'lockbox_passkey_verified');

--- a/src/Models/Lockbox.php
+++ b/src/Models/Lockbox.php
@@ -10,6 +10,14 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Foundation\Auth\User;
 
 /**
+ * Eloquent model storing encrypted lockbox values.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ *
  * @property int    $user_id
  * @property string $name
  * @property string $value
@@ -24,11 +32,21 @@ class Lockbox extends Model
         'value',
     ];
 
+    /**
+     * Get the owning lockboxable model.
+     *
+     * @return MorphTo
+     */
     public function lockboxable(): MorphTo
     {
         return $this->morphTo();
     }
 
+    /**
+     * Relationship to the owning user.
+     *
+     * @return BelongsTo<User, self>
+     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/src/Support/Composer/Package.php
+++ b/src/Support/Composer/Package.php
@@ -6,13 +6,36 @@ namespace N3XT0R\FilamentLockbox\Support\Composer;
 
 use Composer\InstalledVersions;
 
+/**
+ * Utility for querying installed Composer packages.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ */
 class Package
 {
+    /**
+     * Determine whether a Composer package is installed.
+     *
+     * @param string $package Name of the Composer package
+     *
+     * @return bool True if the package is installed, false otherwise
+     */
     public static function isInstalled(string $package): bool
     {
         return InstalledVersions::isInstalled($package);
     }
 
+    /**
+     * Retrieve the version of an installed Composer package.
+     *
+     * @param string $package Name of the Composer package
+     *
+     * @return string|null Package version or null if not installed
+     */
     public static function getVersion(string $package): ?string
     {
         return self::isInstalled($package)

--- a/src/Support/KeyMaterial/CryptoPasswordKeyMaterialProvider.php
+++ b/src/Support/KeyMaterial/CryptoPasswordKeyMaterialProvider.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * Key material provider that derives material from a user's crypto password.
- */
-
 declare(strict_types=1);
 
 namespace N3XT0R\FilamentLockbox\Support\KeyMaterial;
@@ -16,21 +12,37 @@ use RuntimeException;
 
 /**
  * Generates key material from a user-provided crypto password.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
  */
 class CryptoPasswordKeyMaterialProvider implements UserKeyMaterialProviderInterface
 {
     /**
      * Determine if the user has a crypto password configured.
+     *
+     * @param User $user User to check
+     *
+     * @return bool True if a crypto password exists, false otherwise
      */
     public function supports(User $user): bool
     {
-        return $user instanceof HasLockboxKeys && !empty($user->getCryptoPasswordHash());
+        return $user instanceof HasLockboxKeys
+            && !empty($user->getCryptoPasswordHash());
     }
 
     /**
-     * Return key material derived from the validated crypto password.
+     * Derive key material from the provided crypto password.
      *
-     * @throws RuntimeException when the input is missing or invalid
+     * @param User        $user  User providing the password
+     * @param string|null $input Crypto password input
+     *
+     * @throws RuntimeException If the input is missing or invalid
+     *
+     * @return string Derived key material
      */
     public function provide(User $user, ?string $input): string
     {

--- a/src/Support/KeyMaterial/PasskeyKeyMaterialProvider.php
+++ b/src/Support/KeyMaterial/PasskeyKeyMaterialProvider.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * Key material provider that derives encryption material from a user's passkey.
- */
-
 declare(strict_types=1);
 
 namespace N3XT0R\FilamentLockbox\Support\KeyMaterial;
@@ -16,11 +12,21 @@ use Spatie\LaravelPasskeys\Models\Passkey;
 
 /**
  * Provides key material based on verified passkey credentials.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
  */
 class PasskeyKeyMaterialProvider implements UserKeyMaterialProviderInterface
 {
     /**
-     * Determine if the user supports passkey-based key material.
+     * Check whether the user supports passkey-based key material.
+     *
+     * @param User $user User to check
+     *
+     * @return bool True if passkeys are supported, false otherwise
      */
     public function supports(User $user): bool
     {
@@ -28,9 +34,14 @@ class PasskeyKeyMaterialProvider implements UserKeyMaterialProviderInterface
     }
 
     /**
-     * Return deterministic key material derived from the authenticated passkey.
+     * Derive key material from the authenticated passkey.
      *
-     * @throws RuntimeException when passkey data is missing or invalid
+     * @param User        $user  User providing the passkey
+     * @param string|null $input Unused input
+     *
+     * @throws RuntimeException When passkey data is missing or invalid
+     *
+     * @return string Derived key material
      */
     public function provide(User $user, ?string $input): string
     {
@@ -45,7 +56,9 @@ class PasskeyKeyMaterialProvider implements UserKeyMaterialProviderInterface
             throw new RuntimeException('User has no registered passkeys.');
         }
 
-        $sessionData = session()->get(config('filament-lockbox.passkeys.session_flag', 'lockbox_passkey_verified'));
+        $sessionData = session()->get(
+            config('filament-lockbox.passkeys.session_flag', 'lockbox_passkey_verified'),
+        );
         if (empty($sessionData)) {
             throw new RuntimeException('Passkey authentication required.');
         }
@@ -63,6 +76,11 @@ class PasskeyKeyMaterialProvider implements UserKeyMaterialProviderInterface
             throw new RuntimeException('Passkey from session not found for this user.');
         }
 
-        return hash('sha256', hash_hmac('sha256', $passkey->getAttribute('credential_id'), config('app.key')) . $user->getKey(), true);
+        return hash(
+            'sha256',
+            hash_hmac('sha256', $passkey->getAttribute('credential_id'), config('app.key'))
+                . $user->getKey(),
+            true,
+        );
     }
 }

--- a/src/Support/KeyMaterial/TotpKeyMaterialProvider.php
+++ b/src/Support/KeyMaterial/TotpKeyMaterialProvider.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * Key material provider that validates a TOTP code from the user.
- */
-
 declare(strict_types=1);
 
 namespace N3XT0R\FilamentLockbox\Support\KeyMaterial;
@@ -15,22 +11,38 @@ use N3XT0R\FilamentLockbox\Contracts\UserKeyMaterialProviderInterface;
 use RuntimeException;
 
 /**
- * Generates key material using a time-based one-time password (TOTP).
+ * Generates key material using a time-based one-time password.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
  */
 class TotpKeyMaterialProvider implements UserKeyMaterialProviderInterface
 {
     /**
      * Determine if the user has TOTP authentication enabled.
+     *
+     * @param User $user User to check
+     *
+     * @return bool True if TOTP is configured, false otherwise
      */
     public function supports(User $user): bool
     {
-        return $user instanceof HasAppAuthentication && !empty($user->getAppAuthenticationSecret());
+        return $user instanceof HasAppAuthentication
+            && !empty($user->getAppAuthenticationSecret());
     }
 
     /**
-     * Return key material after verifying the provided TOTP code.
+     * Verify the TOTP code and return derived key material.
      *
-     * @throws RuntimeException when verification fails
+     * @param User        $user  User attempting authentication
+     * @param string|null $input TOTP code input
+     *
+     * @throws RuntimeException When verification fails
+     *
+     * @return string Derived key material
      */
     public function provide(User $user, ?string $input): string
     {

--- a/src/Support/LockboxManager.php
+++ b/src/Support/LockboxManager.php
@@ -10,15 +10,34 @@ use Illuminate\Support\Facades\Crypt;
 use N3XT0R\FilamentLockbox\Contracts\HasLockboxKeys;
 use RuntimeException;
 
+/**
+ * Creates encrypter instances for users using lockbox keys.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ */
 class LockboxManager
 {
     /**
-     * Build an Encrypter instance for the given user model.
-     * Combines server-side key (encrypted_user_key) with user-provided input (TOTP or crypto password).
+     * Build an encrypter for the given user model.
+     * Combines the stored encrypted key with user-provided material.
      *
+     * @param User        $user          User to build the encrypter for
+     * @param string|null $input         Optional user-provided secret
+     * @param string|null $providerClass Provider class override
+     *
+     * @throws RuntimeException If required data is missing
+     *
+     * @return Encrypter Encrypter instance for the user
      */
-    public function forUser(User $user, ?string $input = null, ?string $providerClass = null): Encrypter
-    {
+    public function forUser(
+        User $user,
+        ?string $input = null,
+        ?string $providerClass = null,
+    ): Encrypter {
         $this->assertValidUserModel($user);
 
         /** @var User&HasLockboxKeys $user */
@@ -41,9 +60,13 @@ class LockboxManager
     }
 
     /**
-     * Ensures that the given model implements all required interfaces.
+     * Ensure the given model implements required interfaces.
      *
-     * @throws RuntimeException
+     * @param User $user User model to validate
+     *
+     * @throws RuntimeException If the model is invalid
+     *
+     * @return void
      */
     private function assertValidUserModel(User $user): void
     {

--- a/src/Support/LockboxService.php
+++ b/src/Support/LockboxService.php
@@ -8,10 +8,33 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User;
 use N3XT0R\FilamentLockbox\Contracts\HasLockbox;
 
+/**
+ * Service for storing and retrieving lockbox values.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ */
 class LockboxService
 {
-    public function set(Model&HasLockbox $lockboxable, string $name, string $value, User $user): void
-    {
+    /**
+     * Store an encrypted value for a lockboxable model.
+     *
+     * @param Model&HasLockbox $lockboxable Model implementing lockbox relation
+     * @param string           $name        Lockbox item name
+     * @param string           $value       Plain text value to encrypt
+     * @param User             $user        User owning the data
+     *
+     * @return void
+     */
+    public function set(
+        Model&HasLockbox $lockboxable,
+        string $name,
+        string $value,
+        User $user,
+    ): void {
         $encrypter = app(LockboxManager::class)->forUser($user);
 
         $lockboxable->lockbox()->updateOrCreate(
@@ -20,9 +43,21 @@ class LockboxService
         );
     }
 
-    public function get(Model&HasLockbox $lockboxable, string $name, User $user): ?string
-    {
-        /** @var \N3XT0R\FilamentLockbox\Models\Lockbox|null $record */
+    /**
+     * Retrieve and decrypt a value from the lockbox.
+     *
+     * @param Model&HasLockbox $lockboxable Model implementing lockbox relation
+     * @param string           $name        Lockbox item name
+     * @param User             $user        User owning the data
+     *
+     * @return string|null Decrypted value or null when missing
+     */
+    public function get(
+        Model&HasLockbox $lockboxable,
+        string $name,
+        User $user,
+    ): ?string {
+        /** @var \\N3XT0R\\FilamentLockbox\\Models\\Lockbox|null $record */
         $record = $lockboxable->lockbox()
             ->where('name', $name)
             ->where('user_id', $user->getKey())

--- a/src/Support/UserKeyMaterialResolver.php
+++ b/src/Support/UserKeyMaterialResolver.php
@@ -8,6 +8,15 @@ use Illuminate\Foundation\Auth\User;
 use N3XT0R\FilamentLockbox\Contracts\UserKeyMaterialProviderInterface;
 use RuntimeException;
 
+/**
+ * Resolves key material using registered providers.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ */
 class UserKeyMaterialResolver
 {
     /**
@@ -15,18 +24,46 @@ class UserKeyMaterialResolver
      */
     protected array $providers;
 
+    /**
+     * @param iterable<UserKeyMaterialProviderInterface> $providers Providers to register
+     *
+     * @return void
+     */
     public function __construct(iterable $providers = [])
     {
-        $this->providers = is_array($providers) ? $providers : iterator_to_array($providers);
+        $this->providers = is_array($providers)
+            ? $providers
+            : iterator_to_array($providers);
     }
 
+    /**
+     * Register an additional key material provider.
+     *
+     * @param UserKeyMaterialProviderInterface $provider Provider instance
+     *
+     * @return void
+     */
     public function registerProvider(UserKeyMaterialProviderInterface $provider): void
     {
         $this->providers[] = $provider;
     }
 
-    public function resolve(User $user, ?string $input, ?string $providerClass = null): string
-    {
+    /**
+     * Resolve key material for a user.
+     *
+     * @param User        $user          User requiring key material
+     * @param string|null $input         Optional user input
+     * @param string|null $providerClass Specific provider class to use
+     *
+     * @throws RuntimeException If no provider can handle the request
+     *
+     * @return string Derived key material
+     */
+    public function resolve(
+        User $user,
+        ?string $input,
+        ?string $providerClass = null,
+    ): string {
         if ($providerClass !== null) {
             foreach ($this->providers as $provider) {
                 if ($provider::class === $providerClass) {

--- a/src/Testing/TestsFilamentLockbox.php
+++ b/src/Testing/TestsFilamentLockbox.php
@@ -7,6 +7,14 @@ namespace N3XT0R\FilamentLockbox\Testing;
 use Livewire\Features\SupportTesting\Testable;
 
 /**
+ * Testing helpers for Filament Lockbox features.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ *
  * @mixin Testable
  */
 class TestsFilamentLockbox

--- a/src/Widgets/LockboxStatusWidget.php
+++ b/src/Widgets/LockboxStatusWidget.php
@@ -15,6 +15,15 @@ use N3XT0R\FilamentLockbox\Jobs\ReencryptLockboxData;
 use N3XT0R\FilamentLockbox\Support\KeyMaterial\CryptoPasswordKeyMaterialProvider;
 use N3XT0R\FilamentLockbox\Support\KeyMaterial\TotpKeyMaterialProvider;
 
+/**
+ * Widget for managing lockbox configuration in Filament.
+ *
+ * @category Filament Security
+ * @package  n3xt0r/filament-lockbox
+ * @author   Ilya Beliaev
+ * @license  MIT
+ * @link     https://github.com/N3XT0R/filament-lockbox
+ */
 class LockboxStatusWidget extends Widget
 {
     /**
@@ -28,6 +37,11 @@ class LockboxStatusWidget extends Widget
 
     public bool $supportsLockbox = false;
 
+    /**
+     * Initialize widget state and detect lockbox support.
+     *
+     * @return void
+     */
     public function mount(): void
     {
         $user = Auth::user();
@@ -38,6 +52,11 @@ class LockboxStatusWidget extends Widget
         }
     }
 
+    /**
+     * Build the form schema for lockbox settings.
+     *
+     * @return array<int, mixed> Form component definitions
+     */
     public function getFormSchema(): array
     {
         if (!$this->supportsLockbox) {
@@ -61,6 +80,11 @@ class LockboxStatusWidget extends Widget
         ];
     }
 
+    /**
+     * Generate a new user key if missing.
+     *
+     * @return void
+     */
     public function generateKey(): void
     {
         if (!$this->supportsLockbox) {
@@ -86,6 +110,11 @@ class LockboxStatusWidget extends Widget
         $this->dispatch('$refresh');
     }
 
+    /**
+     * Save lockbox settings and re-encrypt data if needed.
+     *
+     * @return void
+     */
     public function saveSettings(): void
     {
         if (!$this->supportsLockbox) {
@@ -128,6 +157,11 @@ class LockboxStatusWidget extends Widget
         $this->totpCode = null;
     }
 
+    /**
+     * Retrieve available key material provider classes.
+     *
+     * @return array<string, string> Mapping of class names to labels
+     */
     protected function getProviderOptions(): array
     {
         $providers = config('filament-lockbox.providers', []);


### PR DESCRIPTION
## Summary
- document all PHP classes and methods with standardized metadata
- include parameter, return, and exception annotations where applicable

## Testing
- `composer lint`
- `composer test` *(fails: No code coverage driver with path coverage support available)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f946238c832982a160694c587983