### PR TITLE
Fix tests by configuring app key and disabling coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "analyse": "phpstan analyse",
         "lint": "pint",
         "refactor": "rector",
-        "test": "vendor/bin/phpunit",
+        "test": "vendor/bin/phpunit --no-coverage",
         "test:lint": "pint --test",
         "test:refactor": "rector --dry-run"
     },

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -64,6 +64,7 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app): void
     {
         $app['config']->set('database.default', 'testing');
+        $app['config']->set('app.key', 'base64:' . base64_encode(random_bytes(32)));
     }
 
     protected function defineDatabaseMigrations(): void


### PR DESCRIPTION
## Summary
- set a default app key during test setup to satisfy encryption requirements
- run PHPUnit without coverage in composer script to avoid coverage warnings

## Testing
- `composer test`
- `composer test:lint`


------
https://chatgpt.com/codex/tasks/task_e_68c73427178c832997f4e072764349d3