### PR TITLE
Use LockboxService in encrypted form components

### DIFF
--- a/src/Support/LockboxService.php
+++ b/src/Support/LockboxService.php
@@ -27,6 +27,7 @@ class LockboxService
      * @param string           $name        Lockbox item name
      * @param string           $value       Plain text value to encrypt
      * @param User             $user        User owning the data
+     * @param string|null      $input       Optional user-provided secret
      *
      * @return void
      */
@@ -35,8 +36,9 @@ class LockboxService
         string           $name,
         string           $value,
         User             $user,
+        ?string          $input = null,
     ): void {
-        $encrypter = app(LockboxManager::class)->forUser($user);
+        $encrypter = app(LockboxManager::class)->forUser($user, $input);
 
         $lockboxable->lockbox()->updateOrCreate(
             ['name' => $name, 'user_id' => $user->getKey()],
@@ -50,6 +52,7 @@ class LockboxService
      * @param Model&HasLockbox $lockboxable Model implementing lockbox relation
      * @param string           $name        Lockbox item name
      * @param User             $user        User owning the data
+     * @param string|null      $input       Optional user-provided secret
      *
      * @return string|null Decrypted value or null when missing
      */
@@ -57,6 +60,7 @@ class LockboxService
         Model&HasLockbox $lockboxable,
         string           $name,
         User             $user,
+        ?string          $input = null,
     ): ?string {
         /** @var Lockbox|null $record */
         $record = $lockboxable->lockbox()
@@ -68,7 +72,7 @@ class LockboxService
             return null;
         }
 
-        $encrypter = app(LockboxManager::class)->forUser($user);
+        $encrypter = app(LockboxManager::class)->forUser($user, $input);
 
         return $encrypter->decrypt($record->getAttribute('value'));
     }

--- a/tests/Integration/EncryptedTextInputTest.php
+++ b/tests/Integration/EncryptedTextInputTest.php
@@ -6,16 +6,18 @@ namespace N3XT0R\FilamentLockbox\Tests\Integration;
 
 use Illuminate\Foundation\Auth\User as BaseUser;
 use Illuminate\Support\Facades\Crypt;
+use N3XT0R\FilamentLockbox\Concerns\InteractsWithLockbox;
+use N3XT0R\FilamentLockbox\Contracts\HasLockbox;
 use N3XT0R\FilamentLockbox\Contracts\HasLockboxKeys;
 use N3XT0R\FilamentLockbox\Contracts\UserKeyMaterialProviderInterface;
 use N3XT0R\FilamentLockbox\Forms\Components\EncryptedTextInput;
-use N3XT0R\FilamentLockbox\Support\LockboxManager;
+use N3XT0R\FilamentLockbox\Support\LockboxService;
 use N3XT0R\FilamentLockbox\Support\UserKeyMaterialResolver;
 use N3XT0R\FilamentLockbox\Tests\TestCase;
 
 class EncryptedTextInputTest extends TestCase
 {
-    public function testDehydrateEncryptsStateWithProvidedInput(): void
+    public function testPersistsAndRetrievesViaLockboxService(): void
     {
         $provider = new class () implements UserKeyMaterialProviderInterface {
             public function supports(BaseUser $user): bool
@@ -33,7 +35,10 @@ class EncryptedTextInputTest extends TestCase
 
         config(['app.key' => 'base64:' . base64_encode(random_bytes(32))]);
 
-        $user = new class () extends BaseUser implements HasLockboxKeys {
+        $user = new class () extends BaseUser implements HasLockboxKeys, HasLockbox {
+            use InteractsWithLockbox;
+            protected $guarded = [];
+            protected $table = 'users';
             public ?string $encryptedUserKey;
             public string $providerClass;
 
@@ -82,16 +87,42 @@ class EncryptedTextInputTest extends TestCase
         };
 
         $user->providerClass = $provider::class;
+        $user->forceFill([
+            'name' => 'Test',
+            'email' => 'test@example.com',
+            'password' => bcrypt('password'),
+        ])->save();
 
         $this->actingAs($user);
 
-        $component = EncryptedTextInput::make('secret')->setLockboxInput('input-secret');
+        $livewire = new class () extends \Livewire\Component implements \Filament\Schemas\Contracts\HasSchemas {
+            use \Filament\Schemas\Concerns\InteractsWithSchemas;
 
-        $encrypted = (\invade($component)->dehydrateStateUsing)('plain-value');
+            public function getSchemas(): array
+            {
+                return [];
+            }
+        };
 
-        $manager = app(LockboxManager::class);
-        $encrypter = $manager->forUser($user, 'input-secret');
+        $component = EncryptedTextInput::make('secret')
+            ->model($user)
+            ->setLockboxInput('input-secret');
+        $component->container(\Filament\Schemas\Schema::make($livewire));
+        $component->state('plain-value');
+        $save = \invade($component)->saveRelationshipsUsing;
+        $save($component);
 
-        $this->assertSame('plain-value', $encrypter->decryptString($encrypted));
+        $service = app(LockboxService::class);
+        $retrieved = $service->get($user, 'secret', $user, 'input-secret');
+        $this->assertSame('plain-value', $retrieved);
+
+        $component2 = EncryptedTextInput::make('secret')
+            ->model($user)
+            ->setLockboxInput('input-secret');
+        $component2->container(\Filament\Schemas\Schema::make($livewire));
+        $hydrate = \invade($component2)->afterStateHydrated;
+        $hydrate($component2);
+        $this->assertSame('plain-value', $component2->getState());
     }
 }
+


### PR DESCRIPTION
## Summary
- store and retrieve encrypted form field values through `LockboxService`
- load lockbox data for a model when hydrating form components
- add integration tests for lockbox form components

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c7457e1f2c83298b8a20e92fd83bfa